### PR TITLE
mbed_app.json -> define SPI PIN  setting  wizchip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+
+## WIZnetInterface Library 
+
+### Program setting for using WiznetInterface in mbed_app.json. 
+ - Define SPI interface pin.
+ - Define Reset Pin for module reset.
+
+```
+{
+    "config": {
+        "network-interface":{
+            "help": "options are ETHERNET, ETHERNET_W5500, ETHERNET_W6100",
+            "value": "ETHERNET_W5500"
+        },
+    "WIZchip-SPI-MOSI": {
+            "help": "Pin used as SPI MOSI (connects to WIZNET CHIP SPI MOSI)",
+            "value": "SPI_MOSI"
+        },
+    "WIZchip-SPI-MISO": {
+            "help": "Pin used as SPI MOSI (connects to WIZNET CHIP SPI MISO)",
+            "value": "SPI_MISO"
+        },
+    "WIZchip-SPI-SCK": {
+            "help": "Pin used as SPI MOSI (connects to WIZNET CHIP SPI SCK)",
+            "value": "SPI_SCK"
+        },
+    "WIZchip-SPI-CS": {
+            "help": "Pin used as SPI MOSI (connects to WIZNET CHIP SPI CS)",
+            "value": "SPI_CS"
+        },
+    "WIZchip-SPI-RESET": {
+            "help": "Pin used as SPI MOSI (connects to WIZNET CHIP SPI RESET)",
+            "value": "D15"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
+            "mbed-trace.enable": 0
+        }
+    }
+}
+```

--- a/WIZnet/W7500x_toe.cpp
+++ b/WIZnet/W7500x_toe.cpp
@@ -200,17 +200,16 @@ void WIZnet_Chip::reset()
 
 #elif defined(TARGET_WIZwiki_W7500P)
 //초기화 추가
-    *(volatile uint32_t *)(0x41003088) = 0x62; //PC12
-    *(volatile uint32_t *)(0x41003054) = 0x62; //PC5
-    *(volatile uint32_t *)(0x41003058) = 0x62; //PC6
+    *(volatile uint32_t *)(0x41003070) = 0x61; //PB12
+    *(volatile uint32_t *)(0x41002054) = 0x01; //PB5 AFC_AFR_AF_0
+    *(volatile uint32_t *)(0x41003054) = 0x61; //PB5
+    *(volatile uint32_t *)(0x41002058) = 0x01; //PB6 AFC_AFR_AF_0
+    *(volatile uint32_t *)(0x41003058) = 0x61; //PB6
+    *(volatile uint32_t *)(0x410020D8) = 0x01; //PD6 AFC_AFR_AF_0
     *(volatile uint32_t *)(0x410030D8) = 0x02; //PD6
 
-    *(volatile uint32_t *)(0x41002054) = 0x01; //PC5 AFC_AFR_AF_0
-    *(volatile uint32_t *)(0x41002058) = 0x01; //PC6 AFC_AFR_AF_0
-    *(volatile uint32_t *)(0x410020D8) = 0x01; //PD6 AFC_AFR_AF_0
-
-    HAL_GPIO_SetBits(GPIOD, GPIO_Pin_6); // PHY reset pin
-    GPIOD->OUTENSET = GPIO_Pin_6; // PHY reset pin
+    *(volatile uint32_t *)(0x45000004) = 0x40; // PHY reset pin
+    *(volatile uint32_t *)(0x45000010) = 0x40; // PHY reset pin
 #endif
 
     // set ticker counter

--- a/WIZnet/wiznet.h
+++ b/WIZnet/wiznet.h
@@ -16,30 +16,30 @@
     #endif
     //#define USE_W5100S // don't use this library
 
-    #if defined MBED_CONF_APP_WIZCHIP_SPI_MOSI
-        #define Wizchip_MOSI MBED_CONF_APP_WIZCHIP_SPI_MOSI
+    #if defined MBED_CONF_WIZNET_MOSI
+        #define WIZNET_MOSI MBED_CONF_WIZNET_MOSI
     #else
-        #define Wizchip_MOSI SPI_MOSI
+        #define WIZNET_MOSI SPI_MOSI
     #endif
-    #if defined MBED_CONF_APP_WIZCHIP_MISO
-        #define Wizchip_MISO MBED_CONF_APP_WIZCHIP_SPI_MISO
+    #if defined MBED_CONF_WIZNET_MISO
+        #define WIZNET_MISO MBED_CONF_WIZNET_MISO
     #else
-        #define Wizchip_MISO SPI_MISO
+        #define WIZNET_MISO SPI_MISO
     #endif
-    #if defined MBED_CONF_APP_WIZCHIP_SCK
-        #define Wizchip_SCK MBED_CONF_APP_WIZCHIP_SPI_SCK
+    #if defined MBED_CONF_WIZNET_SCK
+        #define WIZNET_SCK MBED_CONF_WIZNET_SCK
     #else
-        #define Wizchip_SCK SPI_SCK
+        #define WIZNET_SCK SPI_SCK
     #endif
-    #if defined MBED_CONF_APP_WIZCHIP_CS
-        #define Wizchip_CS MBED_CONF_APP_WIZCHIP_SPI_CS
+    #if defined MBED_CONF_WIZNET_CS
+        #define WIZNET_CS MBED_CONF_WIZNET_CS
     #else
-        #define Wizchip_CS SPI_CS
+        #define WIZNET_CS SPI_CS
     #endif
-    #if defined MBED_CONF_APP_WIZCHIP_RESET
-        #define Wizchip_RESET MBED_CONF_APP_WIZCHIP_SPI_RESET
+    #if defined MBED_CONF_WIZNET_RESET
+        #define WIZNET_RESET MBED_CONF_WIZNET_RESET
     #else
-        #define Wizchip_RESET D15
+        #define WIZNET_RESET D15
     #endif
 #endif
 

--- a/WIZnet/wiznet.h
+++ b/WIZnet/wiznet.h
@@ -8,21 +8,43 @@
     #include "W7500x_toe.h"
 #else
 
-    #define USE_W5500  // don't use this library
-    //#define USE_W5100S // don't use this library
-    //#define USE_W6100  // don't use this library
-
-    #if defined(USE_W5500)
-    #include "W5500.h"
-    //#define USE_WIZ550IO_MAC    // want to use the default MAC address stored in the WIZ550io
+    #if MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET_W5500
+        #define USE_W5500  // don't use this library
+        #include "W5500.h"
+    #elif MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET_W6100
+        #define USE_W6100  // don't use this library
     #endif
+    //#define USE_W5100S // don't use this library
 
+    #if defined MBED_CONF_APP_WIZCHIP_SPI_MOSI
+        #define Wizchip_MOSI MBED_CONF_APP_WIZCHIP_SPI_MOSI
+    #else
+        #define Wizchip_MOSI SPI_MOSI
+    #endif
+    #if defined MBED_CONF_APP_WIZCHIP_MISO
+        #define Wizchip_MISO MBED_CONF_APP_WIZCHIP_SPI_MISO
+    #else
+        #define Wizchip_MISO SPI_MISO
+    #endif
+    #if defined MBED_CONF_APP_WIZCHIP_SCK
+        #define Wizchip_SCK MBED_CONF_APP_WIZCHIP_SPI_SCK
+    #else
+        #define Wizchip_SCK SPI_SCK
+    #endif
+    #if defined MBED_CONF_APP_WIZCHIP_CS
+        #define Wizchip_CS MBED_CONF_APP_WIZCHIP_SPI_CS
+    #else
+        #define Wizchip_CS SPI_CS
+    #endif
+    #if defined MBED_CONF_APP_WIZCHIP_RESET
+        #define Wizchip_RESET MBED_CONF_APP_WIZCHIP_SPI_RESET
+    #else
+        #define Wizchip_RESET D15
+    #endif
 #endif
 
 
 
-//#define ETHERNET          1
-//#define ETERNET_WIZTOE     2
 
 
 

--- a/WIZnetInterface.cpp
+++ b/WIZnetInterface.cpp
@@ -29,9 +29,7 @@ static int udp_local_port = 0;
 #define WIZNET_WAIT_TIMEOUT1   1000
 #define WIZNET_ACCEPT_TIMEOUT 300000 //5 mins timeout, retrun NSAPI_ERROR_WOULD_BLOCK if there is no connection during 5 mins
 
-#define WIZNET_INTF_DBG 0
-
-#if WIZNET_INTF_DBG
+#if MBED_CONF_WIZNET_DEBUG
 #define DBG(...) do{debug("[%s:%d] \n", __PRETTY_FUNCTION__,__LINE__);debug(__VA_ARGS__);} while(0);
 #else
 #define DBG(...) while(0);
@@ -57,7 +55,7 @@ DHCPClient dhcp;
     NetworkInterface *NetworkInterface::get_default_instance()
     {
         //static WIZnetInterface eth(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_CS, D15);
-        static WIZnetInterface eth(Wizchip_MOSI, Wizchip_MISO, Wizchip_SCK, Wizchip_CS, Wizchip_RESET);
+        static WIZnetInterface eth(WIZNET_MOSI, WIZNET_MISO, WIZNET_SCK, WIZNET_CS, WIZNET_RESET);
         return &eth;
     }
 

--- a/WIZnetInterface.cpp
+++ b/WIZnetInterface.cpp
@@ -48,7 +48,6 @@ DHCPClient dhcp;
  * @retval
  */
 /* Interface implementation */
-//#if MBED_CONF_APP_NETWORK_INTERFACE == ETHERNET_TOE
 #if defined(TARGET_WIZwiki_W7500) || defined(TARGET_WIZwiki_W7500ECO) || defined(TARGET_WIZwiki_W7500P)
     NetworkInterface *NetworkInterface::get_default_instance()
     {
@@ -57,7 +56,8 @@ DHCPClient dhcp;
 #else
     NetworkInterface *NetworkInterface::get_default_instance()
     {
-        static WIZnetInterface eth(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_CS, LED1);
+        //static WIZnetInterface eth(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_CS, D15);
+        static WIZnetInterface eth(Wizchip_MOSI, Wizchip_MISO, Wizchip_SCK, Wizchip_CS, Wizchip_RESET);
         return &eth;
     }
 
@@ -70,7 +70,6 @@ DHCPClient dhcp;
         }
 
 #endif
-//#endif
 
 wiznet_socket* WIZnetInterface::get_sock(int fd)
 {

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,39 @@
+{
+    "name": "WIZNET",
+    "config": {
+        "sck": {
+            "help": "sck pin for spi connection. defaults to SPI_SCK",
+            "value": "SPI_SCK"
+        },
+        "cs": {
+            "help": "cs pin for spi connection. defaults to SPI_CS",
+            "value": "SPI_CS"
+        },
+        "miso": {
+            "help": "miso pin for spi connection. defaults to SPI_MISO",
+            "value": "SPI_MISO"
+        },
+        "mosi": {
+            "help": "mosi pin for spi connection. defaults to SPI_MOSI",
+            "value": "SPI_MOSI"
+        },
+        "rst": {
+            "help": "RESET pin for spi connection. defaults to D15",
+            "value": "D15"
+        },
+        "debug": {
+            "help": "Enable debug logs. [true/false]",
+            "value": true
+        },
+        "provide-default": {
+            "help": "Provide default WifiInterface. [true/false]",
+            "value": false
+        },
+        "socket-bufsize": {
+            "help": "Max socket data heap usage",
+            "value": 8192
+        }
+    },
+    "target_overrides": {
+    }
+}


### PR DESCRIPTION
change W7500p GPIO PB12 PB5, PB6 Setting pull down
                               pin setting format  Address input value
------------------------------------------------------------------
in mbed_app.json << define Wiznet chip used SPI pin in json file 
"config": {
        "network-interface":{
            "help": "options are ETHERNET, ETHERNET_W5500, ETHERNET_W6100",
            "value": "ETHERNET_W5500"
        },
    "WIZchip-SPI-MOSI": {
            "help": "Pin used as SPI MOSI (connects to WIZNET CHIP SPI MOSI)",
            "value": "SPI_MOSI"
        }
    },
------------------------------------------------------------------
in wiznet.h   << if SPI pin not defined in json file,  defined default setting
#if defined MBED_CONF_APP_WIZCHIP_SPI_MOSI
        #define Wizchip_MOSI MBED_CONF_APP_WIZCHIP_SPI_MOSI
    #else
        #define Wizchip_MOSI SPI_MOSI
    #endif
    #if defined MBED_CONF_APP_WIZCHIP_MISO
        #define Wizchip_MISO MBED_CONF_APP_WIZCHIP_SPI_MISO
    #else
        #define Wizchip_MISO SPI_MISO
    #endif
    #if defined MBED_CONF_APP_WIZCHIP_SCK
        #define Wizchip_SCK MBED_CONF_APP_WIZCHIP_SPI_SCK
    #else
        #define Wizchip_SCK SPI_SCK
    #endif
    #if defined MBED_CONF_APP_WIZCHIP_CS
        #define Wizchip_CS MBED_CONF_APP_WIZCHIP_SPI_CS
    #else
        #define Wizchip_CS SPI_CS
    #endif
    #if defined MBED_CONF_APP_WIZCHIP_RESET
        #define Wizchip_RESET MBED_CONF_APP_WIZCHIP_SPI_RESET
    #else
        #define Wizchip_RESET D15
    #endif