### PR TITLE
mbed os ver 12.3 change gethostbyname() format

### DIFF
--- a/WIZnetInterface.cpp
+++ b/WIZnetInterface.cpp
@@ -52,13 +52,14 @@ DHCPClient dhcp;
         WIZnetInterface eth;
     }
 #else
+#if defined MBED_CONF_WIZNET_INTERNAL_NETWORK
     NetworkInterface *NetworkInterface::get_default_instance()
     {
         //static WIZnetInterface eth(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_CS, D15);
         static WIZnetInterface eth(WIZNET_MOSI, WIZNET_MISO, WIZNET_SCK, WIZNET_CS, WIZNET_RESET);
         return &eth;
     }
-
+#endif
     WIZnetInterface::WIZnetInterface(PinName mosi, PinName miso, PinName sclk, PinName cs, PinName reset) :
         _wiznet(mosi, miso, sclk, cs, reset)
         {
@@ -553,6 +554,10 @@ nsapi_size_or_error_t WIZnetInterface::socket_recv(nsapi_socket_t handle, void *
             return NSAPI_ERROR_WOULD_BLOCK;
         }
 
+        if(_size > size)
+        {
+            _size = size;
+        }
         retsize = _wiznet.recv(SKT(handle)->fd, (char*)((uint32_t *)data + recved_size), (int)_size);
 //	    printf("[TEST 400] : %d\r\n",recved_size);
 //	    for(idx=0; idx<16; idx++)
@@ -727,7 +732,7 @@ void WIZnetInterface::event()
 }
 
 nsapi_error_t WIZnetInterface::gethostbyname(const char *host,
-        SocketAddress *address, nsapi_version_t version)
+        SocketAddress *address, nsapi_version_t version, const char *interface_name)
 {
     DBG("DNS process %s \n", host);
     bool isOK = dns.lookup(host);

--- a/WIZnetInterface.cpp
+++ b/WIZnetInterface.cpp
@@ -52,7 +52,7 @@ DHCPClient dhcp;
         WIZnetInterface eth;
     }
 #else
-#if defined MBED_CONF_WIZNET_INTERNAL_NETWORK
+#if defined MBED_CONF_WIZNET_DEFAULT_NETWORK
     NetworkInterface *NetworkInterface::get_default_instance()
     {
         //static WIZnetInterface eth(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_CS, D15);

--- a/WIZnetInterface.h
+++ b/WIZnetInterface.h
@@ -113,7 +113,7 @@ public:
      */
     //using NetworkInterface::gethostbyname;
     virtual nsapi_error_t gethostbyname(const char *host,
-            SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);    
+            SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC, const char *interface_name = NULL);    
 
 	int IPrenew(int timeout_ms = 15*1000);
 	uint32_t str_to_ip(const char* str);

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -26,19 +26,18 @@
             "value": true
         },
         "provide-default": {
-            "help": "Provide default WifiInterface. [true/false]",
+            "help": "Provide default WizInterface. [true/false]",
             "value": false
         },
         "socket-bufsize": {
             "help": "Max socket data heap usage",
             "value": 8192
         },
-        "Internal-network": {
-            "help": "Internal network enable",
-            "options" : [null,1],
-            "value": null
+        "default-network": {
+            "help": "Set the default network interface",
+            "options" : [true,false],
+            "value": false
         }
-
     },
     "target_overrides": {
     }

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -32,7 +32,13 @@
         "socket-bufsize": {
             "help": "Max socket data heap usage",
             "value": 8192
+        },
+        "Internal-network": {
+            "help": "Internal network enable",
+            "options" : [null,1],
+            "value": null
         }
+
     },
     "target_overrides": {
     }


### PR DESCRIPTION
add select internal network interface  mbed_lib.json

format  add const char *interface_name
nsapi_error_t WIZnetInterface::gethostbyname(const char *host,
        SocketAddress *address, nsapi_version_t version, const char *interface_name)

select enable get_default_instance()
